### PR TITLE
Switch from OpenSSL 1.0.2 to OpenSSL 3.0

### DIFF
--- a/examples/robsd-regress.conf
+++ b/examples/robsd-regress.conf
@@ -166,7 +166,7 @@ regress "lib/libssl/client"
 regress "lib/libssl/dtls"
 regress "lib/libssl/exporter"
 regress "lib/libssl/handshake"
-regress "lib/libssl/interop" quiet packages { "botan2" "openssl%1.0.2" "openssl%1.1" }
+regress "lib/libssl/interop" quiet packages { "botan2" "openssl%1.1" "openssl%3.0" }
 regress "lib/libssl/key_schedule"
 regress "lib/libssl/openssl-ruby" quiet packages { "openssl-ruby-tests" }
 regress "lib/libssl/pqueue"


### PR DESCRIPTION
OpenSSL 1.0.2 will be removed from the ports tree since it is full of known security issues and no longer receives security updates. interop tests have been updated to pick up OpenSSL 3.0 if it's present.