### PR TITLE
whirlpool was removed

### DIFF
--- a/examples/robsd-regress.conf
+++ b/examples/robsd-regress.conf
@@ -148,7 +148,6 @@ regress "lib/libcrypto/sm3"
 regress "lib/libcrypto/sm4"
 regress "lib/libcrypto/symbols"
 regress "lib/libcrypto/utf8"
-regress "lib/libcrypto/whirlpool"
 regress "lib/libcrypto/wycheproof" no-parallel
 	packages { "go" "wycheproof-testvectors" }
 regress "lib/libcrypto/x509"


### PR DESCRIPTION
This should be the only adjustment needed for today's bump. The rust-openssl test is likely to fail unless you have 20240830p0, everything else is expected to pass.